### PR TITLE
Fix course data path references

### DIFF
--- a/app/components/course_index_manager.py
+++ b/app/components/course_index_manager.py
@@ -1,7 +1,9 @@
 import os
 import json
 
-COURSE_INDEX_PATH = "data/course_index.json"
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+COURSE_INDEX_PATH = os.path.join(BASE_DIR, "data", "course_index.json")
 
 def ensure_index_file_exists():
     """파일이 없으면 빈 리스트로 생성"""

--- a/app/components/course_loader.py
+++ b/app/components/course_loader.py
@@ -1,7 +1,9 @@
 import json
 import os
 
-COURSE_INDEX_PATH = "data/metadata/course_index.json"
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+COURSE_INDEX_PATH = os.path.join(BASE_DIR, "data", "course_index.json")
 
 def load_course_list():
     with open(COURSE_INDEX_PATH, encoding="utf-8") as f:
@@ -12,4 +14,4 @@ def get_course_by_id(course_id):
     return next((c for c in courses if c["course_id"] == course_id), None)
 
 def get_course_path(course_id):
-    return f"data/courses/{course_id}/"
+    return os.path.join(BASE_DIR, "data", "courses", course_id)

--- a/app/components/quiz_generator.py
+++ b/app/components/quiz_generator.py
@@ -7,6 +7,9 @@ from langchain_openai import ChatOpenAI
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_core.documents import Document
 
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
 def generate_mcq_from_text(text: str, num_choices: int = 4) -> dict:
     prompt = f"""
     다음 문단을 읽고, 문단 내용을 바탕으로 하나의 객관식 문제를 생성하세요.
@@ -83,7 +86,7 @@ def generate_quiz_batch_from_docs(docs: List[Document], num_questions: int = 5) 
     return quizzes
 
 def save_quiz(course_id: str, quiz_data: dict):
-    quiz_dir = f"data/courses/{course_id}/quiz"
+    quiz_dir = os.path.join(BASE_DIR, "data", "courses", course_id, "quiz")
     os.makedirs(quiz_dir, exist_ok=True)
 
     # 고유 파일명으로 저장

--- a/app/components/rag_pipeline.py
+++ b/app/components/rag_pipeline.py
@@ -9,6 +9,9 @@ from langchain.chains import RetrievalQA
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import pickle
 
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
 
 def embed_pdf_and_save(course_id: str, pdf_path: str):
     loader = PyMuPDFLoader(pdf_path)
@@ -21,7 +24,7 @@ def embed_pdf_and_save(course_id: str, pdf_path: str):
 
     vectordb = FAISS.from_documents(split_docs, embedding=embeddings)
 
-    save_dir = f"data/courses/{course_id}/index/"
+    save_dir = os.path.join(BASE_DIR, "data", "courses", course_id, "index")
     os.makedirs(save_dir, exist_ok=True)
     vectordb.save_local(save_dir)
 
@@ -31,7 +34,7 @@ def qa_from_course(course_id, question):
     """
     업로드된 교안 벡터를 바탕으로 질의응답 수행
     """
-    vector_path = f"data/courses/{course_id}/index"
+    vector_path = os.path.join(BASE_DIR, "data", "courses", course_id, "index")
 
     if not os.path.exists(vector_path):
         return "❌ 해당 과정의 벡터 데이터가 존재하지 않습니다.", []

--- a/app/tabs/instructor_home.py
+++ b/app/tabs/instructor_home.py
@@ -5,7 +5,9 @@ import re
 import uuid
 from components.course_index_manager import add_course_to_index
 
-COURSE_INDEX_PATH = "data/course_index.json"
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+COURSE_INDEX_PATH = os.path.join(BASE_DIR, "data", "course_index.json")
 
 
 # ✅ course_id 자동 생성 (slug + fallback uuid)

--- a/app/tabs/instructor_quiz.py
+++ b/app/tabs/instructor_quiz.py
@@ -6,6 +6,9 @@ from langchain_openai import OpenAIEmbeddings
 from langchain_community.document_loaders import PyMuPDFLoader
 from components.quiz_generator import generate_quiz_batch_from_docs, save_quiz
 
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
 def show_instructor_quiz():
     st.title("📝 퀴즈 생성기")
     st.markdown("선택한 교안 전체를 기반으로 객관식 퀴즈를 자동 생성합니다.")
@@ -23,7 +26,7 @@ def show_instructor_quiz():
     num_questions = st.slider("생성할 퀴즈 개수", min_value=1, max_value=20, value=5)
 
     # PDF 원본 경로
-    pdf_path = f"data/courses/{course_id}/raw/{course_id}.pdf"
+    pdf_path = os.path.join(BASE_DIR, "data", "courses", course_id, "raw", f"{course_id}.pdf")
     if not os.path.exists(pdf_path):
         st.error("❌ 교안 PDF 파일이 존재하지 않습니다. 업로드 후 다시 시도해주세요.")
         return

--- a/app/tabs/instructor_upload.py
+++ b/app/tabs/instructor_upload.py
@@ -2,8 +2,11 @@ import streamlit as st
 import os
 from components.rag_pipeline import embed_pdf_and_save
 
+# 데이터 디렉터리 절대 경로
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
 def get_course_path(course_id):
-    return os.path.join("data", "courses", course_id)
+    return os.path.join(BASE_DIR, "data", "courses", course_id)
 
 def show_instructor_upload():
     st.title("📥 교안 업로드 및 학습")


### PR DESCRIPTION
## Summary
- centralize data directory access and use absolute paths
- update instructor flow modules to use the new paths

## Testing
- `python -m py_compile app/components/course_index_manager.py app/components/course_loader.py app/components/quiz_generator.py app/components/rag_pipeline.py app/tabs/instructor_home.py app/tabs/instructor_quiz.py app/tabs/instructor_upload.py`

------
https://chatgpt.com/codex/tasks/task_b_688c1701c6f083319cc7736b857bca95