### PR TITLE
Fix course index path

### DIFF
--- a/app/components/course_loader.py
+++ b/app/components/course_loader.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-COURSE_INDEX_PATH = "data/metadata/course_index.json"
+COURSE_INDEX_PATH = "data/course_index.json"
 
 def load_course_list():
     with open(COURSE_INDEX_PATH, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- fix incorrect path in course_loader

## Testing
- `pytest -q`
- manual load check via python

------
https://chatgpt.com/codex/tasks/task_b_688c18e9492883319b336c5421b1fd82