### PR TITLE
fix pdf saving in summary report

### DIFF
--- a/app/components/summary_report.py
+++ b/app/components/summary_report.py
@@ -183,6 +183,11 @@ def _wrap_text_line(line: str, char_width: int = 100) -> str:
     )
 
 def save_text_as_pdf(text: str, output_path: str) -> None:
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+
     effective_w = pdf.w - pdf.l_margin - pdf.r_margin
 
     # 줄 간격(mm)


### PR DESCRIPTION
## Summary
- initialize and configure FPDF in `save_text_as_pdf` to enable PDF generation
- ensure line wrapping and output works without undefined variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bfdb56b048331825e1c601aa4b52b