### PR TITLE
docs: add project overview and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,39 @@
 Streamlit 앱으로 강사와 교육생을 위한 AI 보조 도구를 제공합니다. 교안 업로드 후 질문 응답, 퀴즈 생성 등을 수행할 수 있습니다.
 
 ## 새 기능: 복습 자료 PDF 생성
-
 강사는 업로드한 교안을 기반으로 요약 보고서를 생성하여 PDF로 다운로드할 수 있습니다. 사이드바에서 **📄 복습 자료** 탭을 선택하고 버튼을 누르면 OpenAI API를 활용하여 보고서를 작성하고 PDF로 저장합니다.
-
 보고서는 여러 단계의 프롬프트 체이닝으로 생성됩니다. 교안 내용을 요약한 뒤 사전 학습 내용, 전체 요약과 예제, 후속 학습 로드맵, 기술 전망과 참고 자료, 실습 예제를 순차적으로 생성하고 마지막에 종합해 PDF로 내보냅니다.
+
+## 요구 사항
+- Python 3.11 이상
+- OpenAI API 키 (`OPENAI_API_KEY` 환경 변수)
+- `requirements.txt`에 명시된 패키지: Streamlit, LangChain, OpenAI, FAISS, PyMuPDF, pdfkit 등
+
+## 설치 방법
+```bash
+git clone <repo-url>
+cd ai-teaching
+python -m venv venv
+source venv/bin/activate  # Windows는 venv\Scripts\activate
+pip install -r requirements.txt
+```
+`pdfkit` 사용을 위해 시스템에 `wkhtmltopdf`가 필요할 수 있습니다(Ubuntu: `apt install wkhtmltopdf`).
+
+## 실행 방법
+환경 변수 `OPENAI_API_KEY`를 설정한 후 다음 명령을 실행합니다.
+```bash
+streamlit run app/main_app.py
+```
+
+## 폴더 구조
+```
+app/             Streamlit 앱 소스
+  components/   핵심 기능 모듈
+  tabs/         역할별 탭 화면
+tests/          단위 테스트
+requirements.txt 의존성 목록
+docs/overview.md 상세 설명 자료
+```
+
+## 참고
+전체 코드 구조와 모듈 설명은 [docs/overview.md](docs/overview.md)를 참고하세요.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,45 @@
+# 프로젝트 개요
+
+이 저장소는 **Streamlit** 기반의 "AI 보조강사" 앱을 제공합니다. 강사는 교안을 업로드하여 질문 응답, 퀴즈 생성, 복습 자료 PDF 생성 등을 수행할 수 있고 교육생도 교안을 기반으로 질문하거나 복습할 수 있습니다.
+
+## 디렉터리 구조
+- `app/` – Streamlit 앱 소스
+  - `main_app.py` – 앱 진입점
+  - `login.py` – 간단한 로그인 폼
+  - `router.py` – 로그인된 사용자의 역할에 따라 탭을 전환
+  - `components/` – 핵심 기능 모듈
+    - `course_index_manager.py` – 과정 목록 관리 및 선택
+    - `course_loader.py` – PDF 업로드 및 파일 시스템 저장
+    - `quiz_generator.py` – OpenAI를 이용한 객관식 퀴즈 생성
+    - `rag_pipeline.py` – 교안 PDF를 임베딩하고 질의응답을 수행
+    - `summary_report.py` – 교안 내용을 여러 단계로 요약하여 PDF 보고서 생성
+  - `tabs/` – 각 기능별 Streamlit 탭
+    - `shared_qa.py` – 업로드된 교안을 대상으로 한 공통 질의응답
+    - `instructor_home.py` / `student_home.py` – 역할별 홈 화면
+    - `instructor_upload.py` – 교안 업로드 및 벡터 인덱스 생성
+    - `instructor_quiz.py` – 교안 전체에서 객관식 퀴즈 자동 생성
+    - `instructor_review.py` / `student_review.py` – 복습 자료 PDF 생성 및 열람
+    - `student_quiz.py` – 학습자가 퀴즈를 풀이
+- `tests/` – 단위 테스트(`test_quiz_generator.py`)
+- `requirements.txt` – Python 패키지 의존성 목록
+
+## 주요 패키지
+- **streamlit** – 웹 UI 프레임워크
+- **langchain**, **openai** – LLM 호출 및 RAG 파이프라인 구성
+- **faiss-cpu** – 벡터 데이터베이스
+- **PyMuPDF**, **pdfkit**, **markdown** – PDF 로딩 및 보고서 생성
+- 그 외 `requirements.txt` 참조
+
+## 패키지 설치 방법
+```bash
+python -m venv venv
+source venv/bin/activate  # Windows는 venv\Scripts\activate
+pip install -r requirements.txt
+```
+`pdfkit` 사용을 위해 시스템에 `wkhtmltopdf`가 필요할 수 있습니다(Ubuntu: `apt install wkhtmltopdf`).
+
+## 실행 방법
+환경 변수 `OPENAI_API_KEY`를 설정한 뒤 다음 명령으로 실행합니다.
+```bash
+streamlit run app/main_app.py
+```


### PR DESCRIPTION
## Summary
- expand README with requirements and setup instructions
- document project structure and core modules in docs/overview.md

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac1c31516883318824d80230946092